### PR TITLE
Fixing run script for LD_LIBRARY_PATH could be changed outside of the script

### DIFF
--- a/bin/henplus
+++ b/bin/henplus
@@ -32,7 +32,7 @@ fi
 # position.
 LD_LIBRARY_PATH_EXT=$THISDIR/../lib:/usr/lib/jni
 
-if [ ! -n "$LD_LIBRARY_PATH" ]; then
+if [ -n "$LD_LIBRARY_PATH" ]; then
     LD_LIBRARY_PATH=$LD_LIBRARY_PATH_EXT:$LD_LIBRARY_PATH
 else
     LD_LIBRARY_PATH=$LD_LIBRARY_PATH_EXT


### PR DESCRIPTION
Currently  the script ignores setting of the LD_LIBRARY_PATH that is set before it's run. This just adjust if to get it working.
