### PR TITLE
Ant build explicitly does not include Ant runtime now.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -62,7 +62,7 @@
 
      <target name="compile" depends="prepare,Version.java" 
 	     description="compile it">
-        <javac debug="true" source="1.5" target="1.5" 
+        <javac debug="true" source="1.5" target="1.5" includeantruntime="no"
 	       encoding="ISO-8859-1" srcdir="${src}" destdir="${classes}">
            <classpath refid="compile.classpath" />
         </javac>


### PR DESCRIPTION
When the includeantruntime property on the javac Ant task is not
included it causes warnings to be emitted in the build.  Moreover, the
recommendation in the Ant manual has for many years been to set it to
false.  See:  http://ant.apache.org/manual/index.html