### PR TITLE
ConnectCommand to support connect url alias user password

### DIFF
--- a/src/henplus/commands/ConnectCommand.java
+++ b/src/henplus/commands/ConnectCommand.java
@@ -318,12 +318,16 @@ public class ConnectCommand extends AbstractCommand {
         if ("sessions".equals(cmd)) {
             showSessions();
             return SUCCESS;
-        } else if ("connect".equals(cmd)) {
-            if (argc < 1 || argc > 2) {
+	}
+
+	else if ("connect".equals(cmd)) {
+	    if (argc < 1 || argc > 4) {
                 return SYNTAX_ERROR;
             }
             String url = (String) st.nextElement();
-            String alias = argc == 2 ? st.nextToken() : null;
+            String alias = (argc >=2) ? st.nextToken() : null;
+            String user =  (argc >=3) ? st.nextToken() : null ;
+            String password =  (argc >=4) ? st.nextToken() : null ;
             if (alias == null) {
                 /*
                  * we only got one parameter. So the that single parameter might
@@ -338,7 +342,7 @@ public class ConnectCommand extends AbstractCommand {
                 }
             }
             try {
-                session = new SQLSession(url, null, null);
+		session = new SQLSession(url, user, password);
                 _knownUrls.put(url, url);
                 if (alias != null) {
                     _knownUrls.put(alias, url);


### PR DESCRIPTION
I wanted to use henplus as a script to churn out some queries from different databases. Some thing like 
henplus <<EOF
connect url1 alias1 user1 password1 
...
connect url2 alias2 user2 password2
...

EOF 
Since the connect command  asked user and password on the command prompt, it was not usable as part of a non interactive script. Hence this change. 