### PR TITLE
Fix javac option version error

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -62,7 +62,7 @@
 
      <target name="compile" depends="prepare,Version.java" 
 	     description="compile it">
-        <javac debug="true" source="1.5" target="1.5" includeantruntime="no"
+        <javac debug="true" source="1.6" target="1.6" includeantruntime="no"
 	       encoding="ISO-8859-1" srcdir="${src}" destdir="${classes}">
            <classpath refid="compile.classpath" />
         </javac>


### PR DESCRIPTION
Tackles the problem [javac] error: Target option 1.5 is no longer supported. Use 1.6 or later.